### PR TITLE
Remove .id for the case addon is not installed

### DIFF
--- a/src/commands/lm/setup.ts
+++ b/src/commands/lm/setup.ts
@@ -81,7 +81,7 @@ async function provisionService(accessToken: string, siteId: string) {
 
   const currentAddon = addons.find((addon: netlifyAddon) => addon.service_path === '/.netlify/large-media')
 
-  if (currentAddon.id) {
+  if (currentAddon) {
     return Promise.resolve('Service already provisioned for this site')
   }
 


### PR DESCRIPTION
**- Summary**

That line fails with `TypeError: Cannot read property 'id' of undefined` if there is no addon with the site.

**- Test plan**

Tested locally.

**- Description for the changelog**

Remove .id for the case addon is not installed.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/911433/51776925-d5cf2980-20af-11e9-8430-300acfabe61b.png)
