### PR TITLE
Write the lfs url in .lfsconfig on lm:setup

### DIFF
--- a/src/commands/lm/setup.ts
+++ b/src/commands/lm/setup.ts
@@ -64,7 +64,7 @@ It runs the install command if you have not installed the dependencies yet.
       {
         title: 'Configuring Git LFS for this site',
         task: async function() {
-          await configureLFSURL(accessToken, site.id, api)
+          await configureLFSURL(site.id, api)
         }
       }
     ])
@@ -111,7 +111,7 @@ async function provisionService(accessToken: string, siteId: string) {
   return createAddon(settings, accessToken)
 }
 
-async function configureLFSURL(accessToken: string, siteId: string, api: netlifyClient) {
+async function configureLFSURL(siteId: string, api: netlifyClient) {
   const siteInfo = await api.getSite({ siteId })
   const url = `${siteInfo.ssl_url}/.netlify/large-media`
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

When the addon is configured correctly.
Run this command even when the addon is already provisioned
to ensure that domain updates override this setting.

**- Test plan**

I tested with one of my test sites:

```
➜  web-test2 git:(big_site) ✗ netlify lm:setup
  ✔ Provisioning Netlify Large Media
  ✔ Configuring Git LFS for this site
➜  web-test2 git:(big_site) ✗ cat .lfsconfig
[lfs]
	url = https://happy-borg-f26e76.netlify.com/.netlify/large-media
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://cdn2.img.sputniknews.com/images/105865/19/1058651948.jpg)