### PR TITLE
Use site's id_domain to create the lfs url.

### DIFF
--- a/src/commands/lm/setup.ts
+++ b/src/commands/lm/setup.ts
@@ -8,7 +8,7 @@ const execa = require('execa')
 const Listr = require('listr')
 
 interface siteInfo {
-  ssl_url: string;
+  id_domain: string;
 }
 
 interface siteQuery {
@@ -113,7 +113,7 @@ async function provisionService(accessToken: string, siteId: string) {
 
 async function configureLFSURL(siteId: string, api: netlifyClient) {
   const siteInfo = await api.getSite({ siteId })
-  const url = `${siteInfo.ssl_url}/.netlify/large-media`
+  const url = `https://${siteInfo.id_domain}/.netlify/large-media`
 
   return execa('git', ['config', '-f', '.lfsconfig', 'lfs.url', url])
 }


### PR DESCRIPTION
**- Summary**

Change how we generate the LFS url to use the id_domain returned by the api.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Run the setup locally should update the lfs.url configuration.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://i.ytimg.com/vi/CvdT7OnTihE/maxresdefault.jpg)