### PR TITLE
Don't add Netlify's Git Credential Helper to PATH if it's already in PATH

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -167,6 +167,10 @@ async function extractFile(file: string, helperPath: string) {
 async function setupUnixPath() {
   const shellInfo = shellVariables()
 
+  if (process.env.PATH && process.env.PATH.includes(joinBinPath())) {
+    return true
+  }
+
   const initContent = `
 # The next line updates PATH for Netlify's Git Credential Helper.
 if [ -f '${shellInfo.path}' ]; then source '${shellInfo.path}'; fi


### PR DESCRIPTION
Fixes #24 
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

I am using Fish shell and I can't use Netlify LFS because during installation `lm:install` the following error is thrown:

```
Unable to set credential helper in PATH. We don't how to set the path for fish shell.
Set the helper path in your environment PATH: /Users/florian/.netlify/helper/bin
```

However, even after manually setting the correct PATH `lm:install` tries to set the path again. This PR adds a check if the path to Netlify's Git Credential Helper is already in `PATH` and don't tries to add it again.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Before this PR: https://files.florian.ec/lm-install-before-fix.png
After PR: https://files.florian.ec/lm-install-fix.png

**- Description for the changelog**

Don't add Netlify's Git Credential Helper to PATH if it's already in PATH

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**