### PR TITLE
Add PATH configuration for fish shell

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -194,7 +194,7 @@ fi`
       fs.writeFileSync(shellInfo.path, 'export PATH=${0:A:h}/bin:$PATH')
       return writeConfig('.zshrc', initContent)
     case 'fish':
-      fs.writeFileSync(shellInfo.path, 'set -U fish_user_paths /usr/local/bin $fish_user_paths')
+      fs.writeFileSync(shellInfo.path, 'set -U fish_user_paths (dirname (status --current-filename)) $fish_user_paths')
       return writeConfig('.config/fish/config.fish', `test -f '${shellInfo.path}' && source '${shellInfo.path}'`)
     default:
       const error = `Unable to set credential helper in PATH. We don't how to set the path for ${shellInfo.shell} shell.

--- a/src/install.ts
+++ b/src/install.ts
@@ -193,6 +193,9 @@ fi`
     case 'zsh':
       fs.writeFileSync(shellInfo.path, 'export PATH=${0:A:h}/bin:$PATH')
       return writeConfig('.zshrc', initContent)
+    case 'fish':
+      fs.writeFileSync(shellInfo.path, 'set -U fish_user_paths /usr/local/bin $fish_user_paths')
+      return writeConfig('.config/fish/config.fish', `test -f '${shellInfo.path}' && source '${shellInfo.path}'`)
     default:
       const error = `Unable to set credential helper in PATH. We don't how to set the path for ${shellInfo.shell} shell.
 Set the helper path in your environment PATH: ${joinBinPath()}`


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-cms/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

`fish` shell users are unable to run `netlify lm:install` or `netlify lm:setup` successfully. This change enables the plugin to function when running inside `fish`.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

I made this change, ran `netlify plugins:link`, then my LFS setup worked (as tested via `git push` and seeing the LFS objects get pushed up).

**- Description for the changelog**

Add PATH configuration for fish shell

**- A picture of a cute animal (not mandatory but encouraged)**

Here's a potato-quality picture of my cat:

![IMG_20200723_104044](https://user-images.githubusercontent.com/508402/103379262-b5cdef00-4aaa-11eb-89b4-3ab77935abf5.jpg)